### PR TITLE
Add title and optimize the size of the picture taken

### DIFF
--- a/lib/src/main/java/com/soundcloud/android/crop/Crop.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/Crop.java
@@ -24,6 +24,7 @@ public class Crop {
         String MAX_X = "max_x";
         String MAX_Y = "max_y";
         String ERROR = "error";
+        String TITLE = "title";
     }
 
     private Intent cropIntent;
@@ -74,6 +75,16 @@ public class Crop {
     public Crop withMaxSize(int width, int height) {
         cropIntent.putExtra(Extra.MAX_X, width);
         cropIntent.putExtra(Extra.MAX_Y, height);
+        return this;
+    }
+
+    /**
+     * Set title
+     *
+     * @param title The title
+     */
+    public Crop withTitle(String title) {
+        cropIntent.putExtra(Extra.TITLE, title);
         return this;
     }
 

--- a/lib/src/main/java/com/soundcloud/android/crop/CropImageView.java
+++ b/lib/src/main/java/com/soundcloud/android/crop/CropImageView.java
@@ -145,11 +145,11 @@ public class CropImageView extends ImageViewTouchBase {
     private void ensureVisible(HighlightView hv) {
         Rect r = hv.drawRect;
 
-        int panDeltaX1 = Math.max(0, getLeft() - r.left);
-        int panDeltaX2 = Math.min(0, getRight() - r.right);
+        int panDeltaX1 = Math.max(0, 0 - r.left);
+        int panDeltaX2 = Math.min(0, getWidth() - r.right);
 
-        int panDeltaY1 = Math.max(0, getTop() - r.top);
-        int panDeltaY2 = Math.min(0, getBottom() - r.bottom);
+        int panDeltaY1 = Math.max(0, 0 - r.top);
+        int panDeltaY2 = Math.min(0, getHeight() - r.bottom);
 
         int panDeltaX = panDeltaX1 != 0 ? panDeltaX1 : panDeltaX2;
         int panDeltaY = panDeltaY1 != 0 ? panDeltaY1 : panDeltaY2;

--- a/lib/src/main/res/layout/crop__activity_crop.xml
+++ b/lib/src/main/res/layout/crop__activity_crop.xml
@@ -5,6 +5,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <TextView
+        android:id="@+id/title_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Frame your picture"
+        style="@style/Crop.TitleBar"/>
+
     <include
         android:id="@+id/done_cancel_bar"
         layout="@layout/crop__layout_done_cancel" />

--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
     <style name="Crop.DoneCancelBar">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">@dimen/crop__bar_height</item>
+        <item name="android:layout_below">@id/title_bar</item>
         <item name="android:orientation">horizontal</item>
         <item name="android:divider">@drawable/crop__divider</item>
         <item name="android:showDividers" tools:ignore="NewApi">middle</item>
@@ -39,6 +40,15 @@
     <style name="Crop.ActionButtonText.Cancel">
         <item name="android:drawableLeft">@drawable/crop__ic_cancel</item>
         <item name="android:text">@string/crop__cancel</item>
+    </style>
+
+    <style name="Crop.TitleBar">
+        <item name="android:gravity">center</item>
+        <item name="android:paddingTop">5dp</item>
+        <item name="android:background">@color/crop__button_bar</item>
+        <item name="android:textColor">@color/crop__button_text</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">13sp</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Deux changements et une correction dans cette PR:
1. On a ajouté une barre de titre.
2. On maximise la taille de la zone de crop.

Le correctif est de tenir compte du fait que les absolus de `getTop()`, `getBottom()`, `getLeft()` et `getRight()` ne sont pas bons pour positionner la vue. On doit se baser sur la visibilité de l'image à l'intérieure de la vue.
